### PR TITLE
Update hotel booking information deadline

### DIFF
--- a/reggie_config/super_2019/init.yaml
+++ b/reggie_config/super_2019/init.yaml
@@ -34,6 +34,7 @@ reggie:
 
         dates:
           prereg_open: 2018-08-24
+          prereg_hotel_eligibility_cutoff: 2018-09-04
           shifts_created: 2018-11-02
           room_deadline: 2018-11-29
           shirt_deadline: 2018-12-01

--- a/reggie_config/super_2019/init.yaml
+++ b/reggie_config/super_2019/init.yaml
@@ -34,7 +34,7 @@ reggie:
 
         dates:
           prereg_open: 2018-08-24
-          prereg_hotel_eligibility_cutoff: 2018-09-04
+          prereg_hotel_eligibility_cutoff: 2018-09-03
           shifts_created: 2018-11-02
           room_deadline: 2018-11-29
           shirt_deadline: 2018-12-01


### PR DESCRIPTION
Supermag 2019 registrants must register by 11:59pm monday sept 3 to be eligible to receive hotel booking info.