### PR TITLE
Add refund_start and refund_cutoff

### DIFF
--- a/reggie_config/super_2019/init.yaml
+++ b/reggie_config/super_2019/init.yaml
@@ -49,6 +49,8 @@ reggie:
           prereg_takedown: 2019-01-04
           group_prereg_takedown: 2019-01-04
           badge_price_waived: 2019-01-06 12
+          refund_start: 2018-09-05
+          refund_cutoff: 2018-09-30
 
           printed_badge_deadline: 2018-11-10
 


### PR DESCRIPTION
Dates are currently placeholder until/unless we get sign off on them. Remember that all dates without specific times are end-of-day.