### PR TITLE
Enable send_sms for production

### DIFF
--- a/reggie_config/prod/init.yaml
+++ b/reggie_config/prod/init.yaml
@@ -9,6 +9,7 @@ reggie:
     ubersystem:
       config:
         send_emails: True
+        send_sms: True
         dev_box: False
 
 


### PR DESCRIPTION
Just realized we never enabled sms on production for things like tabletop or attractions.