### PR TITLE
Add sweatpants sizes to Super config

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -104,6 +104,14 @@ reggie:
             band: RockStar
             under_13: 12 & Under
             mivs: Indie Dev
+            
+          sweatpants:
+            no_sweatpants: Select a sweatpants size
+            s: S
+            m: M
+            l: L
+            xl: XL
+            2xl: 2XL
 
           job_location:
             console: Consoles


### PR DESCRIPTION
This is required for https://github.com/magfest/magprime/pull/267 to work, since we can't add this config via the magprime plugin. Please do not remove this config without also changing the code in our magprime plugin.