### PR TITLE
MAGDEV-330: Vagrant environments can send emails again

### DIFF
--- a/reggie_config/dev/init.yaml
+++ b/reggie_config/dev/init.yaml
@@ -14,6 +14,9 @@ reggie:
         send_emails: True
         dev_box: True
 
+        celery:
+          beat_schedule_filename: /tmp/celerybeat-schedule.db
+
         secret:
           stripe_secret_key: 'sk_test_QHnlImUs68dQFxgTfVauz5Ue'
           stripe_public_key: 'pk_test_q4kSJVwk6LXKv2ahxuVn7VOK'


### PR DESCRIPTION
Celery uses ``dbm`` for persistent storage, which is built on top of the ``gdbm`` C library.  Some testing has revealed that this works when creating or opening files on a native filesystem but not on a mounted filesystem.  For example:

```python
>>> import dbm
>>> db = dbm.open('/tmp/foo.db', 'c')
>>> db = dbm.open('/home/vagrant/reggie-formula/foo.db', 'c')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/dbm/__init__.py", line 94, in open
    return mod.open(file, flag, mode)
_gdbm.error: [Errno 22] Invalid argument
```

This is the same argument that we get when running the ``reggie-scheduler`` service.  Therefore, this fix is to change the location of the scheduler database from living under ``/home/vagrant/reggie-formula`` (which is a mounted filesystem) to live under the native ``/tmp`` filesystem.

This seems to have broken within the past several months.  I'll also leave a comment at https://github.com/pydanny/cookiecutter-django/issues/1793 explaining this find, since someone using Docker seems to have run into the same issue.