### PR TITLE
Added support for event 'tags' such as 'onsite'

### DIFF
--- a/magfest_state/salt/cloud/files/cloud.profiles.d/reggie-onsite-staging-profiles.conf
+++ b/magfest_state/salt/cloud/files/cloud.profiles.d/reggie-onsite-staging-profiles.conf
@@ -17,6 +17,7 @@ base-staging:
   minion:
     grains:
       env: staging
+      event_tag: onsite
       event_name: super
       event_year: 2019
       

--- a/reggie_config/init.yaml
+++ b/reggie_config/init.yaml
@@ -1,6 +1,7 @@
 {%- set env = __grains__['env'] -%}
 {%- set event_name = __grains__['event_name'] -%}
 {%- set event_year = __grains__['event_year'] -%}
+{%- set event_tag = __grains__.get('event_tag', '') -%}
 {%- set private_ip = __grains__['ip4_interfaces'][__grains__.get('private_interface', 'eth1')][0] -%}
 {%- set loadbalancer_id = __salt__['saltutil.runner']('mine.get',
     tgt='G@roles:reggie and G@roles:loadbalancer and G@env:' ~ env ~ ' and G@event_name:' ~ event_name ~ ' and G@event_year:' ~ event_year,

--- a/reggie_config/loadbalancer.yaml
+++ b/reggie_config/loadbalancer.yaml
@@ -1,10 +1,15 @@
-{%- from 'init.yaml' import env, event_name, event_year, private_ip -%}
+{%- from 'init.yaml' import env, event_name, event_year, event_tag, private_ip -%}
 {%- set port = stack['reggie'].get('port', 443) -%}
 {%- set nonssl_port = stack['reggie'].get('nonssl_port', 80) -%}
 {%- set url_path = stack['reggie'].get('cherrypy_mount_path', '/reggie') -%}
 {%- set loadbalancer_password = stack['reggie'].get('loadbalancer', {}).get('password') -%}
+{%- if event_tag -%}
+  {%- set tag_match = 'G@event_tag:' ~ event_tag -%}
+{%- else -%}
+  {%- set tag_match = 'not G@event_tag:*' -%}
+{%- endif -%}
 {%- set backends = __salt__['saltutil.runner']('mine.get',
-    tgt='G@roles:reggie and G@roles:web and G@env:' ~ env ~ ' and G@event_name:' ~ event_name ~ ' and G@event_year:' ~ event_year,
+    tgt='G@roles:reggie and G@roles:web and G@env:' ~ env ~ ' and G@event_name:' ~ event_name ~ ' and G@event_year:' ~ event_year ~ ' and ' ~ tag_match,
     fun='private_ip',
     tgt_type='compound').items() %}
 


### PR DESCRIPTION
This is the fix that @kitsuta and I discussed last night.  There's a new optional ``event_tag`` grain that can be set.  This should be backwards-compatible by virtue of being optional.  If an event doesn't set this for any of its servers, then everything should work exactly the same as before.  If a server DOES set this, then it's used to tell HAProxy which web workers to load balance.

The problem before was that HAProxy was finding all web workers with a matching environment (prod/staging), event name, and event year.  So if we wanted 2 different staging servers, one for onsite and one for precon mode, then the HAProxy server for each of them would grab the web workers for both stacks.  This led to a situation where on both https://staging-reggie.magfest.org and https://onsite-staging-reggie.magfest.org we'd end up seeing the onsite version 25% of the time and the precon version 75% of the time (since there's 1 onsite and 3 precon web workers).

I've tested this change on mcp by editing these files, and both servers are currently working.  Until this is merged, I think that'll get blown away the next time someone does a deploy, so I'm gonna merge this now, having already tested it, then do a few deploys to make extra sure that it all works.