### PR TITLE
turned off db backups for onsite server

### DIFF
--- a/reggie_config/onsite.reggie.magfest.org/init.yaml
+++ b/reggie_config/onsite.reggie.magfest.org/init.yaml
@@ -1,6 +1,9 @@
 __: merge-first
 
 reggie:
+  db:
+    backups:
+      enabled: False
   plugins:
     ubersystem:
       config:


### PR DESCRIPTION
Thus turns off trying to scp backups to the backup server, which is on a Digital Ocean we don't have access to.  We still take backups, but they're not being copied off the server, which we'll want to address in the next few days as we go live.