### PR TITLE
renamed onsite reggie to onsite uber because of laptop configuration

### DIFF
--- a/reggie_config/onsite.uber.magfest.org/init.yaml
+++ b/reggie_config/onsite.uber.magfest.org/init.yaml
@@ -7,4 +7,4 @@ reggie:
   plugins:
     ubersystem:
       config:
-        at_the_con: True
+        at_the_con: False


### PR DESCRIPTION
I renamed the server from onsite.reggie.magfest.org to onsite.uber.magfest.org because the latter is what the techops laptops expect.

I also set at the con mode to False because we don't want to set that until tomorrow at around 4pm.  We'll make another change then.