### PR TITLE
added onsite redirection

### DIFF
--- a/magfest_config/defaults.sls
+++ b/magfest_config/defaults.sls
@@ -14,7 +14,9 @@ master:
 
 
 minion:
+{% if salt_env != 'onsite' %}
   master: {{ master_ip }}
+{% endif %}
 
   log_file: file:///dev/log
   log_level: info

--- a/reggie_config/loadbalancer.yaml
+++ b/reggie_config/loadbalancer.yaml
@@ -3,6 +3,7 @@
 {%- set nonssl_port = stack['reggie'].get('nonssl_port', 80) -%}
 {%- set url_path = stack['reggie'].get('cherrypy_mount_path', '/reggie') -%}
 {%- set loadbalancer_password = stack['reggie'].get('loadbalancer', {}).get('password') -%}
+{%- set onsite_redirect_host = stack['reggie'].get('onsite_redirect_host', '') -%}
 {%- if event_tag -%}
   {%- set tag_match = 'G@event_tag:' ~ event_tag -%}
 {%- else -%}
@@ -75,6 +76,12 @@ haproxy:
           host: 127.0.0.1
           port: 9999
 
+{% if onsite_redirect_host %}
+    reggie_onsite_redirect:
+      mode: http
+      bind: "0.0.0.0:{{ port }} ssl crt {{ stack['ssl']['certs_dir'] }}/{{ minion_id }}.pem"
+      httprequests: 'redirect location https://{{ onsite_redirect_host }}%[capture.req.uri] code 301'
+{% else %}
   frontends:
     reggie_load_balancer:
       mode: http
@@ -132,3 +139,4 @@ haproxy:
           port: 8080
           extra: 'check'
         {%- endfor %}
+{% endif %}


### PR DESCRIPTION
There are two changes here, which I've already tested:

1) We need to NOT set the salt master ip address for the onsite server.  What happens is that the onsite server needs to reach out to mcp.magfest.net instead of using its backnet ip.  So we check whether the environment is "onsite" and then we don't supply the backnet ip in that case.  This is backwards-compatible and also allows our onsite server to work.

2) If the ``reggie:onsite_redirect_host`` pillar entry is set, then HAProxy will now redirect to the configured onsite server.  If not set then HAProxy just works as before.  This is how we'll have the current live site redirect to the onsite server once that's up and running.

I'm going to merge this in right away, since this is what's already running on mcp anyway and I've already been doing deploys to staging to make sure this works.