### PR TITLE
raised badge bump for after we sell out

### DIFF
--- a/reggie_config/super_2019/init.yaml
+++ b/reggie_config/super_2019/init.yaml
@@ -24,7 +24,7 @@ reggie:
         # and group registrations which we support.  In other words, we will only
         # cut off preregistration once that sum meets this number no matter how
         # many other registrations (Staff, Dealers, Guests, etc) are in the system.
-        max_badge_sales: 22500
+        max_badge_sales: 22999
 
         # The number of dealer apps we will accept before auto-waitlisting further
         # applications. If dealer_reg_deadline is also set, we will auto-wailist


### PR DESCRIPTION
NOTE: this shouldn't be merged in until noon.

Here's an overly detailed description of this one-line change.

Based on our projections, we should have more than enough badges to last until noon when the badges automatically become free.  However, we will definitely run out of badges in this afternoon after that point.  So here's the plan:

-> We continue selling badges as normal until noon.  The badge cap is currently configured to match the badges we actually have based on a rigorous count, so in the extremely unlikely event that we run out, the system will behave correctly and cut us off at the correct place.

-> Once badges become free, then I will accept this MR and we'll revert to the plan discussed and coordinated with the Dorsai as described in the ``#reg-management`` Slack channel.