### PR TITLE
turn the onsite server AND the prod server into maintenance mode

### DIFF
--- a/reggie_config/onsite.uber.magfest.org/init.yaml
+++ b/reggie_config/onsite.uber.magfest.org/init.yaml
@@ -1,7 +1,7 @@
 __: merge-first
 
 reggie:
-  maintenance: False
+  maintenance: True
   db:
     backups:
       enabled: False

--- a/reggie_config/reggie.magfest.org/init.yaml
+++ b/reggie_config/reggie.magfest.org/init.yaml
@@ -1,4 +1,4 @@
 __: merge-first
 
 reggie:
-  onsite_redirect_host: onsite.uber.magfest.org
+  maintenance: True

--- a/reggie_config/reggie.magfest.org/init.yaml
+++ b/reggie_config/reggie.magfest.org/init.yaml
@@ -1,4 +1,0 @@
-__: merge-first
-
-reggie:
-  maintenance: True

--- a/reggie_config/super_2019_prod/init.yaml
+++ b/reggie_config/super_2019_prod/init.yaml
@@ -6,4 +6,4 @@ reggie:
     ubersystem:
       config:
         at_the_con: False
-        post_con: False
+        post_con: True


### PR DESCRIPTION
We're getting ready to move back to the Cloud!  The procedure looks like this:

1) All at once, change both the onsite server and prod server config as follows:
- Turn off the redirect from https://reggie.magfest.org/ to https://onsite.uber.magfest.org/
- Set both the onsite server and prod server into maintenance mode so that it shows the "back soon" page with the donut ascii art.  (The prod server is already in maintenance mode, it just hasn't mattered because the redirect supersedes that.)
- Deploy to prod and then to onsite.

2) Once both servers are basically offline, take a final db snapshot on the onsite server and copy it over to the prod server, replacing its database with the latest from onsite.

3) Make a followup PR which turns OFF maintenance mode from reggie.magfest.org.  Confirm that everything is back up.

I'll coordinate with Stops about merging and deploying this.