### PR TITLE
Changes to website URLs for reg emails

### DIFF
--- a/reggie_config/west_2019/init.yaml
+++ b/reggie_config/west_2019/init.yaml
@@ -14,6 +14,9 @@ reggie:
         event_year: 2019
         
         consent_form_url: ''
+        code_of_conduct_url: 'https://www.magwest.org/code-of-conduct'
+        prereg_faq_url: 'https://www.magwest.org/faq'
+        contact_url: 'https://www.magwest.org/contact-us'
         expected_response: August 15, 2019
 
         dates:


### PR DESCRIPTION
added c.CODE_OF_CONDUCT_URL, c.PREREG_FAQ_URL, and c.CONTACT_URL to be correctly referenced in upcoming launch emails.