### PR TITLE
Push out Supporter deadline by a month

### DIFF
--- a/reggie_config/west_2019/init.yaml
+++ b/reggie_config/west_2019/init.yaml
@@ -32,7 +32,7 @@ reggie:
           prereg_open: 2019-04-26 12
           shifts_created: 2019-06-01
           shirt_deadline: 2019-08-01
-          supporter_deadline: 2019-07-01
+          supporter_deadline: 2019-08-01
           uber_takedown: 2019-09-16
           room_deadline: 2019-07-31
 


### PR DESCRIPTION
The shirt and printed badge deadlines are already set for August 1st, so we just need to change the Supporter deadline to let people buy kick-ins for a while longer.