### PR TITLE
Upgrade Salt on minions to fix openssl error

### DIFF
--- a/magfest_state/salt/cloud/manager.sls
+++ b/magfest_state/salt/cloud/manager.sls
@@ -30,7 +30,7 @@
           ssh_key_file: /etc/salt/pki/cloud/digitalocean.pem
           ssh_key_names: {{ salt['pillar.get']('digitalocean:ssh_key_names') }}
           script: bootstrap-salt
-          script_args: -P git 'v2018.3.2'
+          script_args: -P git 'v2019.2.0'
 
 /etc/salt/pki/cloud/digitalocean.pem:
   file.managed:


### PR DESCRIPTION
New deploys are failing because an openssl update broke stuff with Salt (https://github.com/saltstack/salt/issues/49661) -- we're fixing it by updating to the latest version of Salt.