### PR TITLE
Keep using the new NGINX formula

### DIFF
--- a/magfest_state/top.sls
+++ b/magfest_state/top.sls
@@ -76,7 +76,7 @@ base:
     - reggie_deploy.ssl
     - reggie_deploy.glusterfs
     - glusterfs.client
-    - nginx.ng
+    - nginx
     - reggie.web
     - reggie_deploy.web
 

--- a/reggie_config/web.yaml
+++ b/reggie_config/web.yaml
@@ -44,118 +44,117 @@ glusterfs:
 
 
 nginx:
-  ng:
-    certificates_path: {{ stack['ssl']['certs_dir'] }}
-    dh_param:
-      dhparams.pem:
-        keysize: 2048
-    service:
-      enable: True
-    server:
-      config:
-        worker_processes: auto
-        worker_rlimit_nofile: 65536
+  certificates_path: {{ stack['ssl']['certs_dir'] }}
+  dh_param:
+    dhparams.pem:
+      keysize: 2048
+  service:
+    enable: True
+  server:
+    config:
+      worker_processes: auto
+      worker_rlimit_nofile: 65536
 
-        events:
-          worker_connections: 65536
+      events:
+        worker_connections: 65536
 
-        http:
-          client_body_buffer_size: 128k
-          client_max_body_size: 20m
-          gzip: 'on'
-          gzip_min_length: 10240
-          gzip_proxied: expired no-cache no-store private auth
-          gzip_types: text/plain text/css text/xml text/javascript application/x-javascript application/json application/xml
-          reset_timedout_connection: 'on'
-          proxy_cache_path: '/var/cache/nginx levels=1:2 keys_zone=one:8m max_size=3000m inactive=600m'
-          server_tokens: 'off'
-          include:
-            - /etc/nginx/mime.types
-            - /etc/nginx/conf.d/*.conf
-            - /etc/nginx/sites-enabled/*
+      http:
+        client_body_buffer_size: 128k
+        client_max_body_size: 20m
+        gzip: 'on'
+        gzip_min_length: 10240
+        gzip_proxied: expired no-cache no-store private auth
+        gzip_types: text/plain text/css text/xml text/javascript application/x-javascript application/json application/xml
+        reset_timedout_connection: 'on'
+        proxy_cache_path: '/var/cache/nginx levels=1:2 keys_zone=one:8m max_size=3000m inactive=600m'
+        server_tokens: 'off'
+        include:
+          - /etc/nginx/mime.types
+          - /etc/nginx/conf.d/*.conf
+          - /etc/nginx/sites-enabled/*
 
-    servers:
-      managed:
-        default:
-          enabled: False
-          config: []
+  servers:
+    managed:
+      default:
+        enabled: False
+        config: []
 
-        reggie_site:
-          enabled: True
-          overwrite: True
-          config:
-            - server:
-              - server_name: localhost
-              - listen: '127.0.0.1:8443 ssl'
-              - listen: '{{ private_ip }}:8443 ssl'
-              - root: /var/www
-              - error_page: 503 @maintenance
+      reggie_site:
+        enabled: True
+        overwrite: True
+        config:
+          - server:
+            - server_name: localhost
+            - listen: '127.0.0.1:8443 ssl'
+            - listen: '{{ private_ip }}:8443 ssl'
+            - root: /var/www
+            - error_page: 503 @maintenance
 
-              {{ nginx_ssl_config(
-                  stack['ssl']['certs_dir'] ~ '/' ~ minion_id ~ '.key',
-                  stack['ssl']['certs_dir'] ~ '/' ~ minion_id ~ '.crt',
-                  stack['ssl']['certs_dir'] ~ '/dhparams.pem')|indent(14) }}
+            {{ nginx_ssl_config(
+                stack['ssl']['certs_dir'] ~ '/' ~ minion_id ~ '.key',
+                stack['ssl']['certs_dir'] ~ '/' ~ minion_id ~ '.crt',
+                stack['ssl']['certs_dir'] ~ '/dhparams.pem')|indent(14) }}
 
-              - 'location @maintenance':
-                - rewrite: ^(.*)$ /maintenance.html break
+            - 'location @maintenance':
+              - rewrite: ^(.*)$ /maintenance.html break
 
-              - 'location = /reggie/robots.txt':
-                - rewrite: ^(.*)$ /reggie/static_views/robots.txt last
+            - 'location = /reggie/robots.txt':
+              - rewrite: ^(.*)$ /reggie/static_views/robots.txt last
 
-              {%- for location in ['/preregistration', '/preregistration/', '/preregistration/form'] %}
-              - 'location = {{ url_path }}{{ location }}':
-                - proxy_hide_header: Cache-Control
-                {{ nginx_proxy_config(cache='/etc/nginx/reggie_short_term_cache.conf')|indent(16) }}
-              {%- endfor %}
+            {%- for location in ['/preregistration', '/preregistration/', '/preregistration/form'] %}
+            - 'location = {{ url_path }}{{ location }}':
+              - proxy_hide_header: Cache-Control
+              {{ nginx_proxy_config(cache='/etc/nginx/reggie_short_term_cache.conf')|indent(16) }}
+            {%- endfor %}
 
-              {%- for location in ['/static/', '/static_views/'] %}
-              - 'location {{ url_path }}{{ location }}':
-                {{ nginx_proxy_config(cache='/etc/nginx/reggie_long_term_cache.conf')|indent(16) }}
-              {%- endfor %}
+            {%- for location in ['/static/', '/static_views/'] %}
+            - 'location {{ url_path }}{{ location }}':
+              {{ nginx_proxy_config(cache='/etc/nginx/reggie_long_term_cache.conf')|indent(16) }}
+            {%- endfor %}
 
-              - 'location /':
-                {{ nginx_proxy_config()|indent(16) }}
+            - 'location /':
+              {{ nginx_proxy_config()|indent(16) }}
 
-            - server:
-              - server_name: localhost
-              - listen: '127.0.0.1:8080'
-              - listen: '{{ private_ip }}:8080'
+          - server:
+            - server_name: localhost
+            - listen: '127.0.0.1:8080'
+            - listen: '{{ private_ip }}:8080'
 
-              - access_log: /var/log/nginx/access_static.log
-              - error_log: /var/log/nginx/error_static.log
+            - access_log: /var/log/nginx/access_static.log
+            - error_log: /var/log/nginx/error_static.log
 
-              {%- for location in ['/static/', '/static_views/'] %}
-              - 'location {{ url_path }}{{ location }}':
-                {{ nginx_proxy_config(cache='/etc/nginx/reggie_long_term_cache.conf')|indent(16) }}
-              {%- endfor %}
+            {%- for location in ['/static/', '/static_views/'] %}
+            - 'location {{ url_path }}{{ location }}':
+              {{ nginx_proxy_config(cache='/etc/nginx/reggie_long_term_cache.conf')|indent(16) }}
+            {%- endfor %}
 
-              - 'location /':
-                - return: '301 https://$host:8443$request_uri'
+            - 'location /':
+              - return: '301 https://$host:8443$request_uri'
 
-        reggie_long_term_cache.conf:
-          enabled: True
-          available_dir: /etc/nginx
-          enabled_dir: /etc/nginx
-          config:
-            - proxy_cache: one
-            - proxy_cache_key: $host$request_uri|$request_body
-            - proxy_cache_valid: 200 60m
-            - proxy_cache_use_stale: error timeout invalid_header updating http_500 http_502 http_503 http_504
-            - proxy_cache_bypass: $http_secret_header $arg_nocache
-            - add_header: X-Cache-Status $upstream_cache_status
+      reggie_long_term_cache.conf:
+        enabled: True
+        available_dir: /etc/nginx
+        enabled_dir: /etc/nginx
+        config:
+          - proxy_cache: one
+          - proxy_cache_key: $host$request_uri|$request_body
+          - proxy_cache_valid: 200 60m
+          - proxy_cache_use_stale: error timeout invalid_header updating http_500 http_502 http_503 http_504
+          - proxy_cache_bypass: $http_secret_header $arg_nocache
+          - add_header: X-Cache-Status $upstream_cache_status
 
-        reggie_short_term_cache.conf:
-          enabled: True
-          available_dir: /etc/nginx
-          enabled_dir: /etc/nginx
-          config:
-            - proxy_cache: one
-            - proxy_cache_key: $host$request_uri
-            - proxy_cache_valid: 200 20s
-            - proxy_cache_lock: 'on'
-            - proxy_cache_lock_age: 40s
-            - proxy_cache_lock_timeout: 40s
-            - proxy_cache_use_stale: error timeout invalid_header updating http_500 http_502 http_503 http_504
-            - proxy_cache_bypass: $http_secret_header $cookie_nocache $arg_nocache $args
-            - proxy_no_cache: $http_secret_header $cookie_nocache $arg_nocache $args
-            - add_header: X-Cache-Status $upstream_cache_status
+      reggie_short_term_cache.conf:
+        enabled: True
+        available_dir: /etc/nginx
+        enabled_dir: /etc/nginx
+        config:
+          - proxy_cache: one
+          - proxy_cache_key: $host$request_uri
+          - proxy_cache_valid: 200 20s
+          - proxy_cache_lock: 'on'
+          - proxy_cache_lock_age: 40s
+          - proxy_cache_lock_timeout: 40s
+          - proxy_cache_use_stale: error timeout invalid_header updating http_500 http_502 http_503 http_504
+          - proxy_cache_bypass: $http_secret_header $cookie_nocache $arg_nocache $args
+          - proxy_no_cache: $http_secret_header $cookie_nocache $arg_nocache $args
+          - add_header: X-Cache-Status $upstream_cache_status


### PR DESCRIPTION
The old NGINX method (called `nginx`) was removed, and the formula we used was renamed to just `nginx`, so we have to update our reference to it.