### PR TITLE
Add social media fields for panelists

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -65,6 +65,14 @@ reggie:
         band_email: MAGFest Music Department <music@magfest.org>
         band_email_signature: '- MAGFest Music Department'
 
+        social_media: ["Social Media Info"]
+
+        social_media_urls:
+          social_media_info: ""
+
+        social_media_placeholders:
+          social_media_info: "List social media sites you use and include a link to your page, or your username."
+
         integer_enums:
           shirt:
             - no shirt: 0

--- a/reggie_config/west/init.yaml
+++ b/reggie_config/west/init.yaml
@@ -62,6 +62,20 @@ reggie:
           guest_badge: [1000, 1999]
           attendee_badge: [2000, 9999]
 
+        social_media: ["Facebook", "Twitter", "Instagram", "LinkedIn"]
+
+        social_media_urls:
+          facebook: "https://www.facebook.com/{}"
+          twitter: "https://twitter.com/{}"
+          instagram: "https://www.instagram.com/{}"
+          linked_in: "https://www.linkedin.com/in/{}"
+
+        social_media_placeholders:
+          facebook: "Facebook page or username"
+          twitter: "Twitter profile or username"
+          instagram: "Instagram page or username"
+          linked_in: "LinkedIn page or username"
+
         enums:
           interest:
             console: "Consoles"


### PR DESCRIPTION
We're removing the social media fields from our base plugin, as the Panels dept for Super wants the options to be different now. They'll live here instead.