### PR TITLE
Presell all kick-in levels until MAGWest 2019

### DIFF
--- a/reggie_config/west_2019/init.yaml
+++ b/reggie_config/west_2019/init.yaml
@@ -11,8 +11,10 @@ reggie:
   plugins:
     ubersystem:
       config:
-        supporter_stock: 100
-        season_stock: 20
+        shirt_stock: 300
+        supporter_stock: 72
+        season_stock: 22
+        shared_kickin_stocks: False
         event_year: 2019
         max_dealers: 5
         
@@ -31,8 +33,8 @@ reggie:
           placeholder_deadline: 2019-09-09
           prereg_open: 2019-04-26 12
           shifts_created: 2019-06-01
-          shirt_deadline: 2019-08-01
-          supporter_deadline: 2019-08-01
+          shirt_deadline: 2019-09-12
+          supporter_deadline: 2019-09-12
           uber_takedown: 2019-09-16
           room_deadline: 2019-07-31
 


### PR DESCRIPTION
Part of https://jira.magfest.net/browse/MAGDEV-540 -- this updates MAGWest's stock of its kickin levels and their deadlines so we can sell kick-ins until the event.