### PR TITLE
West Printed Badge Deadline Change

### DIFF
--- a/reggie_config/west_2019/init.yaml
+++ b/reggie_config/west_2019/init.yaml
@@ -38,7 +38,7 @@ reggie:
           uber_takedown: 2019-09-16
           room_deadline: 2019-07-31
 
-          printed_badge_deadline: 2019-08-01
+          printed_badge_deadline: 2019-08-06
 
           # Dealer registration automatically opens on DEALER_REG_START.  After DEALER_REG_DEADLINE
           # all dealer registration are automatically waitlisted.  After DEALER_REG_SHUTDOWN dealers


### PR DESCRIPTION
We need the printed badge deadline updated to today briefly so we can convert some attendee badges to staff badges. There are some last minute additions (BoD, Employees, etc) that need to be put into the system and given staff badges, but Reggie won't assign additional staff badges after this deadline has passed.