### PR TITLE
Update MIVS config variable names

### DIFF
--- a/reggie_config/labs/init.yaml
+++ b/reggie_config/labs/init.yaml
@@ -32,11 +32,10 @@ reggie:
           band_bio_deadline: 2018-10-21
           guest_bio_deadline: 2018-10-21
 
-          mivs_round_one_deadline: 1970-01-01
-          mivs_round_two_start: 1970-01-01
-          mivs_round_two_deadline: 1970-01-01
+          mivs_deadline: 1970-01-01
+          mivs_start: 1970-01-01
           mivs_judging_deadline: 1970-01-01
-          mivs_round_two_complete: 1970-01-01
+          mivs_results_reveal: 1970-01-01
 
         table_prices:
           default_price: 80

--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -32,7 +32,6 @@ reggie:
         # have to pay are not counted towards this cap. A value of 0 means no cap.
         max_dealer_apps: 530
 
-        mivs_video_response_expected: "no later than September 17th"
         mivs_confirm_deadline: 14
         mivs_submission_grace_period: 10
         mivs_start_year: 2013
@@ -69,11 +68,10 @@ reggie:
           dealer_payment_due: 2019-11-04
           dealer_waitlist_closed: ''  # If this is enabled, be sure to update the waitlist_closing.txt email
 
-          mivs_round_one_deadline: 2019-09-02
-          mivs_round_two_start: 2019-09-22
-          mivs_round_two_deadline: 2019-10-07
+          mivs_start: 2019-09-01
+          mivs_deadline: 2019-09-30
           mivs_judging_deadline: 2019-11-04
-          mivs_round_two_complete: 2019-11-05
+          mivs_results_reveal: 2019-11-05
           
           mits_submission_deadline: 2019-11-14
           mits_editing_deadline: 2019-12-28

--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -69,9 +69,9 @@ reggie:
           dealer_waitlist_closed: ''  # If this is enabled, be sure to update the waitlist_closing.txt email
 
           mivs_start: 2019-09-01
-          mivs_deadline: 2019-09-30
-          mivs_judging_deadline: 2019-11-04
-          mivs_results_reveal: 2019-11-05
+          mivs_deadline: 2019-09-22
+          mivs_judging_deadline: 2019-10-20
+          mivs_results_reveal: 2019-10-28
           
           mits_submission_deadline: 2019-11-14
           mits_editing_deadline: 2019-12-28


### PR DESCRIPTION
Part of fixing https://jira.magfest.net/browse/MAGDEV-544. Also sets the MIVS start date to September 1st for Super 2020, which is MIVS' current launch target.