### PR TITLE
Account for 11:59pm MIVS start date

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -68,7 +68,7 @@ reggie:
           dealer_payment_due: 2019-11-04
           dealer_waitlist_closed: ''  # If this is enabled, be sure to update the waitlist_closing.txt email
 
-          mivs_start: 2019-09-01
+          mivs_start: 2019-08-31
           mivs_deadline: 2019-09-22
           mivs_judging_deadline: 2019-10-20
           mivs_results_reveal: 2019-10-28


### PR DESCRIPTION
If MIVS wants to open on 9/1, we actually need to make it open 8/31, because the default open time is 11:59pm.