### PR TITLE
Remove default job locations

### DIFF
--- a/reggie_config/labs/init.yaml
+++ b/reggie_config/labs/init.yaml
@@ -72,40 +72,6 @@ reggie:
           ribbon:
             band: RockStar
 
-          job_location:
-            console: Consoles
-            arcade: Arcade
-            lan: LAN
-            music: Music
-            panels: Panels
-            tabletop: Tabletop
-            loading_crew: Loading Crew
-            registration: Registration
-            bridge_simulator: Escape Room
-            techops: Tech Ops / AV
-            dispatch: Dispatch
-            jamspace: Jamspace
-            marketplace: Marketplace
-            stops: Stops
-            fest_ops: Guest
-            charity: Charity
-            dorsai: Dorsai
-            mops: Mediatron!
-            merch: Merchandise
-            rescuers: Rescuers
-            security: Security
-            staff_support: Staff Support
-            ccg_tabletop: Tabletop (CCG)
-            tea_room: Tea Room
-            treasury: Treasury
-            concert_security: Concert Security
-            makerspace: Makerspace
-            museum: Computer Museum
-            lego_room: Lego Room
-            music_av: Music A/V
-            games_on_film: Games on Film
-            vrcade: VRCade
-
           job_interest:
             console: Consoles
             arcade: Arcade

--- a/reggie_config/stock/init.yaml
+++ b/reggie_config/stock/init.yaml
@@ -121,14 +121,6 @@ reggie:
           ribbon:
             roughing_it: Roughing It
 
-          job_location:
-            misc: General Support
-            registration: Registration
-            food: Food Prep
-            activities: Events
-            music: Music Pavilion
-            cat_herding: Security
-
           job_interest:
             misc: General Support
             registration: Registration

--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -131,61 +131,6 @@ reggie:
             xl: XL
             2xl: 2XL
 
-          job_location:
-            console: Consoles
-            arcade: Arcade
-            arcade_crew: Arcade_Crew
-            attendee_service: Attendee Services
-            autographs: Autographs
-            challenges: Challenges
-            charity: Charity
-            chipspace: Chipspace
-            concert_ops: Main Theater Operations
-            concert_tech: Main Theater Tech
-            con_ops: Fest Ops
-            dispatch: Dispatch
-            dorsai: Dorsai
-            escape_room: Escape Room
-            events: Events
-            hotel: Hotel
-            panels: Panels
-            food_prep: Staff Suite
-            film_fest: Games on Film
-            indie_arcade: Indie Arcade
-            indie_games: Indie Games
-            indie_tabletop: Indie Tabletop
-            jamspace: Jam Space
-            lan: LAN
-            larp: LARP
-            loadin: Logistics
-            loudr: Rock Island
-            mages: MAGES
-            marketplace: Marketplace
-            merch: Merchandise
-            merch_contractor: Yetee Staff
-            mops: MEDIATRON!
-            museum: Museum
-            music: Music
-            public_safety: Public Safety
-            regdesk: Registration
-            reg_managers: Reg Managers
-            rescuers: Rescuers
-            security: Security
-            shedspace: Jam Clinic
-            signage: Signage
-            simulations: Simulations
-            staff_support: Staff Support
-            tea_room: Staff Tea Room
-            stops: Staffing Ops
-            tabletop: Tabletop
-            tabletop_rpg: Tabletop (Pathfinder)
-            tabletop_ddal: Tabletop (DDAL)
-            tabletop_ccg: Tabletop (CCG)
-            treasury: Treasury
-            tech_ops: Tech Ops
-            vrzone: VRZone
-            zombie_tag: Zombie Tag
-
           job_interest:
             anything: Anything
             arcade: Arcade


### PR DESCRIPTION
Now that we can import departments and their roles from prior events, having default departments is inconvenient, so we're removing them from our config.