### PR TITLE
Remove smartquotes from Super 2020 Kick-in tiers

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -158,7 +158,7 @@ reggie:
           supporter:
             name: Supporter Tier
             icon: ../static/icons/supporter.png
-            description: MAGFest Fanny Pack|Custom Lanyard|Squeezy-nanner|Jungle Sunglasses|Funky Bandana|Gold “MF” Coin|Collapsible Canteen|Barrel Swadge
+            description: MAGFest Fanny Pack|Custom Lanyard|Squeezy-nanner|Jungle Sunglasses|Funky Bandana|Gold "MF" Coin|Collapsible Canteen|Barrel Swadge
             link: ../static_views/supporter.html|../static_views/swadge.html
 
           barrel_roller:


### PR DESCRIPTION
It seems these are breaking deploys. Fun!