### PR TITLE
Remove shiftless departments from config

### DIFF
--- a/reggie_config/labs/init.yaml
+++ b/reggie_config/labs/init.yaml
@@ -18,8 +18,6 @@ reggie:
         tabletop_locations: ['tabletop_tournaments', 'tabletop_tournaments_2', 'tabletop_indie']
         music_rooms: ['concerts', 'chiptunes', 'jamspace', 'jam_clinic']
 
-        shiftless_depts: ['dorsai', 'bridge_simulator', 'marketplace']
-
         require_dedicated_guest_table_presence: False
         rock_island_groups: ['band', 'guest']
 

--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -23,8 +23,6 @@ reggie:
         tabletop_locations: ['tabletop_tournaments', 'tabletop_tournaments_2', 'tabletop_indie']
         music_rooms: ['concerts', 'chiptunes', 'pose_lounge', 'lobby_bar', 'jamspace', 'jam_clinic', 'jam_shop']
 
-        shiftless_depts: ['dorsai', 'marketplace', 'simulations', 'merch_contractor', 'con_ops', 'arcade_crew']
-
         discountable_badge_types: ['attendee_badge', 'child_badge']
 
         accessibility_services_enabled: True


### PR DESCRIPTION
We configure these in the database now, so it should be okay to remove them.