### PR TITLE
Actually start staff badge range at 7

### DIFF
--- a/reggie_config/west/init.yaml
+++ b/reggie_config/west/init.yaml
@@ -58,7 +58,7 @@ reggie:
         band_email_signature: "- MAGWest Music Department"
 
         badge_ranges:
-          staff_badge: [25, 999]
+          staff_badge: [7, 999]
           guest_badge: [1000, 1999]
           attendee_badge: [2000, 9999]
 

--- a/reggie_config/west_2019/init.yaml
+++ b/reggie_config/west_2019/init.yaml
@@ -28,9 +28,6 @@ reggie:
         treasury_dept_checklist_form_url: 'https://docs.google.com/spreadsheets/d/1QlnYaZq5MMvpI8-NQ4m_TdVUfmswfT7GLdjciQcLEBM/edit?usp=sharing'
         expected_response: August 15, 2019
         mivs_video_response_expected: "no later than September 17th"
-        
-        badge_ranges:
-          staff_badge: [7, 999]
 
         dates:
           epoch: 2019-09-13 08


### PR DESCRIPTION
Apparently, you can't override badge ranges in downstream config or you'll get an error like this:
```
sideboard.config.ConfigurationError: configuration validation error(s) (): [(['badge_ranges'], 'staff_badge', VdtValueTooLongError('the value "[\'25\', \'999\', \'7\', \'999\']" is too long.',))]
```

So this removes the 'override' and changes the original instead.