### PR TITLE
Pin Super 2019 to appropriate branches

### DIFF
--- a/reggie_config/super_2019/init.yaml
+++ b/reggie_config/super_2019/init.yaml
@@ -9,7 +9,11 @@ reggie:
         {{ extra_attendance_data()|indent(8) }}
 
   plugins:
+    magprime:
+      branch: super2019
+
     ubersystem:
+      branch: super2019
       config:
         event_year: 2019
         event_qr_id: sm19


### PR DESCRIPTION
A deploy was run against the old Super instance, causing it to break due to the extreme changes in the code. I've made branches from the latest commits in January for both ubersystem and magprime, and this will pin Super 2019 to those branches so we can get that server back to the proper state.