### PR TITLE
Correct name of Treasury step

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -244,7 +244,7 @@ reggie:
           printed_signs:
             deadline: 2019-11-27
 
-          allotments:
+          treasury:
             deadline: 2019-11-27
             
           logistics:


### PR DESCRIPTION
Finally found what was breaking our deploys -- I had renamed a dept head checklist step in one file but not the other.