### PR TITLE
Update shifts created to reflect the actual deadline

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -44,7 +44,7 @@ reggie:
         dates:
           prereg_open: 2019-09-10 15
           prereg_hotel_eligibility_cutoff: 2019-09-17
-          shifts_created: 2019-11-02
+          shifts_created: 2019-10-27
           room_deadline: 2019-11-14
           shirt_deadline: 2019-11-25
           supporter_deadline: 2019-11-18


### PR DESCRIPTION
We changed the "shifts" step deadline for the Dept Head Checklist, but not the corresponding date that lets us release the volunteer checklist. Now we'll be able to send the email!