### PR TITLE
Only presell Unisex shirts for Super

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -107,6 +107,17 @@ reggie:
             - XL Women's slim fit: 22
             - 2XL Women's slim fit: 23
 
+          prereg_shirt:
+            - no shirt: 0
+            - S Unisex: 1
+            - M Unisex: 2
+            - L Unisex: 3
+            - XL Unisex: 4
+            - 2XL Unisex: 5
+            - 3XL Unisex: 6
+            - 4XL Unisex: 11
+            - 5XL Unisex: 12
+
           staff_event_shirt:
             "Two Staff Shirts": 0
             "One Event Shirt and One Staff Shirt": 1


### PR DESCRIPTION
We can fulfill existing orders for non-unisex shirts, but we can't continue offering them for preorder. Depends on https://github.com/magfest/ubersystem/pull/3596.