### PR TITLE
Turn off hotel eligible step in dept head checklist

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -328,11 +328,12 @@ reggie:
                 who haven't claimed their badges.
             path: /dept_checklist/placeholders?department_id={department_id}
 
-          hotel_eligible:
-            deadline: 1970-01-01
-            name: Staffers Requesting Hotel Space
-            description: Double check that everyone in your department who you know needs hotel space has requested it.
-            path: /dept_checklist/hotel_eligible?department_id={department_id}
+          # Turned off for Super 2020 as Tuber does not have the relevant page
+          #hotel_eligible:
+          #  deadline: 1970-01-01
+          #  name: Staffers Requesting Hotel Space
+          #  description: Double check that everyone in your department who you know needs hotel space has requested it.
+          #  path: /dept_checklist/hotel_eligible?department_id={department_id}
 
           tech_requirements:
             deadline: 1970-01-01

--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -240,8 +240,8 @@ reggie:
           social_media:
             deadline: 2019-11-13
 
-          hotel_eligible:
-            deadline: 2019-11-20
+          #hotel_eligible:
+          #  deadline: 2019-11-20
 
           approve_setup_teardown:
             deadline: 2019-11-20


### PR DESCRIPTION
We need to turn this step off for Super 2020 because the new hotel requests system doesn't have a corresponding page. We'll revisit next year.