### PR TITLE
Add contractor badge as preassigned badge type

### DIFF
--- a/reggie_config/init.yaml
+++ b/reggie_config/init.yaml
@@ -101,7 +101,7 @@ reggie:
         panels_twilio_number: '+12405415595'
         tabletop_twilio_number: '+15713646627'
 
-        preassigned_badge_types: ['staff_badge',]
+        preassigned_badge_types: ['staff_badge','contractor_badge']
 
         admin_email: MAGFest Sys Admin <sysadmin@magfest.org>
         developer_email: MAGFest Software <developers@magfest.org>

--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -111,7 +111,8 @@ reggie:
         badge_ranges:
           staff_badge: [25, 2999]
           guest_badge: [3000, 3600]
-          attendee_badge: [3601, 39999]
+          contractor_badge: [3601, 4999]
+          attendee_badge: [5000, 39999]
           one_day_badge: [40000, 49999]
           child_badge: [50000, 59999]
 


### PR DESCRIPTION
We want contractor badges to be preprinted, but with a range right after staff badges to easily separate them.