### PR TITLE
Turn off nginx schedule hiding

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -4,7 +4,6 @@ __: merge-first
 {% macro extra_attendance_data() %}{% include 'super_2020/extra-attendance-data.json' %}{% endmacro %}
 
 reggie:
-  schedule_disabled: True
   extra_files:
     plugins/uber/uber/static/analytics/extra-attendance-data.json: |
         {{ extra_attendance_data()|indent(8) }}


### PR DESCRIPTION
This was a temporary measure to lock down the schedule until we had a chance to make the code not show our schedule while it was still in progress. Part of fixing https://jira.magfest.net/browse/MAGDEV-733.