### PR TITLE
Update supporter and printed badge deadlines

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -47,7 +47,7 @@ reggie:
           shifts_created: 2019-10-27
           room_deadline: 2019-11-14
           shirt_deadline: 2019-11-25
-          supporter_deadline: 2019-11-18
+          supporter_deadline: 2020-01-02
           placeholder_deadline: 2019-12-26
           uber_takedown: 2020-01-07
           epoch: 2020-01-02 08
@@ -58,7 +58,7 @@ reggie:
           refund_start: 2019-09-30
           refund_cutoff: 2019-10-31
 
-          printed_badge_deadline: 2019-11-15
+          printed_badge_deadline: 2019-11-23
 
           # Dealer registration automatically opens on DEALER_REG_START.  After DEALER_REG_DEADLINE
           # all dealer registration are automatically waitlisted.  After DEALER_REG_SHUTDOWN dealers


### PR DESCRIPTION
These deadlines passed but they need to still be enabled. We don't have a solid deadline for printed badges yet, so I pushed it out to this weekend to give us a few days of breathing room.