### PR TITLE
Put Stock 2019 in post-con mode

### DIFF
--- a/reggie_config/stock_2019/init.yaml
+++ b/reggie_config/stock_2019/init.yaml
@@ -12,8 +12,8 @@ reggie:
     ubersystem:
       config:
         event_year: 2019
-        at_the_con: True
-        post_con: False
+        at_the_con: False
+        post_con: True
 
         dates:
           epoch: 2019-06-06 10


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-744. West is already in post-con mode so we just need to change Stock.