### PR TITLE
Pin Stock to West's code

### DIFF
--- a/reggie_config/stock_2019/init.yaml
+++ b/reggie_config/stock_2019/init.yaml
@@ -10,6 +10,7 @@ reggie:
 
   plugins:
     ubersystem:
+      branch: west2019
       config:
         event_year: 2019
         at_the_con: False


### PR DESCRIPTION
We made breaking changes for Super, so we can't deploy to older instances. We'll get around this by pinning Stock to West's branch, which should be compatible.