### PR TITLE
Remove Contractor badge from preassigned badge types

### DIFF
--- a/reggie_config/stock_2019/init.yaml
+++ b/reggie_config/stock_2019/init.yaml
@@ -15,6 +15,7 @@ reggie:
         event_year: 2019
         at_the_con: False
         post_con: True
+        preassigned_badge_types: ['staff_badge']
 
         dates:
           epoch: 2019-06-06 10


### PR DESCRIPTION
This will hopefully fix deploys to Stock 2019.