### PR TITLE
Make staff and contractor badge ranges mergeable

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -113,10 +113,10 @@ reggie:
           guest_travel_plans_deadline: 2019-10-21
 
         badge_ranges:
-          staff_badge: [25, 2999]
-          guest_badge: [3000, 3600]
-          contractor_badge: [3601, 4999]
-          attendee_badge: [5000, 39999]
+          staff_badge: [25, 1999]
+          contractor_badge: [2000, 2999]
+          guest_badge: [3000, 3499]
+          attendee_badge: [3500, 39999]
           one_day_badge: [40000, 49999]
           child_badge: [50000, 59999]
 


### PR DESCRIPTION
We want contractor badges to be a separate range from staff badges _for our badge export_ so that we can easily put "Contractor" stickers on those badges. HOWEVER, when it comes to assigning blank badges, we want to use one range of blank badges for both Staff and Contractors.

Our plan was to use separate ranges for the export and then merge them afterwards. The catch here is that the system doesn't support two sets of ranges for one badge type -- because the guest badge range was splitting staff and contractor ranges, we wouldn't have been able to merge the badge types' ranges properly. So to fix that we're rejiggering the ranges before the export. After the export, both staff and contractor badges will use the range 25, 2999.