### PR TITLE
Turn on separate staff merch

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -14,8 +14,10 @@ reggie:
         event_venue: The Gaylord National Hotel and Convention Center
         event_venue_address: 201 Waterfront St, National Harbor, MD 20745
 
+        separate_staff_merch: true
         shirts_per_staffer: 2
         hours_for_shirt: 12
+        hours_for_food: 12
 
         mits_enabled: True
         mivs_enabled: True


### PR DESCRIPTION
STOPS will be handing out the staff merch separately from merch, so we need to turn this on. Also adds the new hours_for_food variable.