### PR TITLE
Increase row load limit for groups page

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -21,6 +21,7 @@ reggie:
 
         mits_enabled: True
         mivs_enabled: True
+        row_load_limit: 750
 
         volunteer_perks_url: 'https://www.notion.so/magfest/MAGFest-Super-Perks-f001221c31484ef4957a6513c54a6fd6'
 


### PR DESCRIPTION
The default of 500 is too low and our Marketplace head can't see all dealer groups, so we're increasing it for now.