### PR TITLE
added files for onsite

### DIFF
--- a/magfest_state/docker_magbot/init.sls
+++ b/magfest_state/docker_magbot/init.sls
@@ -122,8 +122,10 @@ docker_magbot:
     - log_opt:
       - tag: magbot
     - networks:
+      - docker_network_external
       - docker_network_internal
     - require:
+      - docker_network: docker_network_external
       - docker_network: docker_network_internal
     - watch_any:
       - file: {{ salt['pillar.get']('data:path') }}/magbot/config.py

--- a/magfest_state/top.sls
+++ b/magfest_state/top.sls
@@ -92,3 +92,6 @@ base:
 
   'G@roles:reggie and G@roles:worker':
     - reggie.worker
+
+  'G@roles:reggie and G@env:onsite':
+    - zabbix

--- a/magfest_state/zabbix/init.sls
+++ b/magfest_state/zabbix/init.sls
@@ -1,0 +1,33 @@
+{% set zabbix_pkgname = salt['grains.filter_by']({
+  'Arch': 'zabbix-agent',
+  'RedHat': 'zabbix30-agent',
+  'Debian': 'zabbix-agent'
+  }, grain='os_family', default='Arch')
+%}
+
+zabbix-agent:
+  pkg.installed:
+    - name: {{ zabbix_pkgname }}
+  service.running:
+    - enable: True
+    - reload: True
+    - require:
+      - pkg: zabbix-agent
+      - file: /etc/zabbix/zabbix_agentd.conf
+      - file: /var/run/zabbix
+
+/etc/zabbix/zabbix_agentd.conf:
+  file.managed:
+    - source: salt://zabbix/zabbix_agentd.conf
+    - makedirs: True
+    - require:
+      - pkg: zabbix-agent
+    - watch_in:
+      - service: zabbix-agent
+
+/var/run/zabbix:
+  file.directory:
+    - user: zabbix
+    - group: zabbix
+    - mode: '0755'
+

--- a/magfest_state/zabbix/zabbix_agentd.conf
+++ b/magfest_state/zabbix/zabbix_agentd.conf
@@ -1,0 +1,394 @@
+# This is a configuration file for Zabbix agent daemon (Unix)
+# To get more information about Zabbix, visit http://www.zabbix.com
+
+############ GENERAL PARAMETERS #################
+
+### Option: PidFile
+#       Name of PID file.
+#
+# Mandatory: no
+# Default:
+# PidFile=/tmp/zabbix_agentd.pid
+
+PidFile=/var/run/zabbix/zabbix_agentd.pid
+
+### Option: LogType
+#       Specifies where log messages are written to:
+#               system  - syslog
+#               file    - file specified with LogFile parameter
+#               console - standard output
+#
+# Mandatory: no
+# Default:
+# LogType=file
+
+### Option: LogFile
+#       Log file name for LogType 'file' parameter.
+#
+# Mandatory: no
+# Default:
+# LogFile=
+
+LogFile=/var/log/zabbix/zabbix_agentd.log
+
+### Option: LogFileSize
+#       Maximum size of log file in MB.
+#       0 - disable automatic log rotation.
+#
+# Mandatory: no
+# Range: 0-1024
+# Default:
+# LogFileSize=1
+
+LogFileSize=0
+
+### Option: DebugLevel
+#       Specifies debug level:
+#       0 - basic information about starting and stopping of Zabbix processes
+#       1 - critical information
+#       2 - error information
+#       3 - warnings
+#       4 - for debugging (produces lots of information)
+#       5 - extended debugging (produces even more information)
+#
+# Mandatory: no
+# Range: 0-5
+# Default:
+# DebugLevel=3
+
+### Option: SourceIP
+#       Source IP address for outgoing connections.
+#
+# Mandatory: no
+# Default:
+# SourceIP=
+
+### Option: EnableRemoteCommands
+#       Whether remote commands from Zabbix server are allowed.
+#       0 - not allowed
+#       1 - allowed
+#
+# Mandatory: no
+# Default:
+# EnableRemoteCommands=0
+
+### Option: LogRemoteCommands
+#       Enable logging of executed shell commands as warnings.
+#       0 - disabled
+#       1 - enabled
+#
+# Mandatory: no
+# Default:
+# LogRemoteCommands=0
+
+##### Passive checks related
+
+### Option: Server
+#       List of comma delimited IP addresses (or hostnames) of Zabbix servers.
+#       Incoming connections will be accepted only from the hosts listed here.
+#       If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally.
+#
+# Mandatory: no
+# Default:
+# Server=
+
+Server=10.101.22.200
+
+### Option: ListenPort
+#       Agent will listen on this port for connections from the server.
+#
+# Mandatory: no
+# Range: 1024-32767
+# Default:
+# ListenPort=10050
+
+### Option: ListenIP
+#       List of comma delimited IP addresses that the agent should listen on.
+#       First IP address is sent to Zabbix server if connecting to it to retrieve list of active checks.
+#
+# Mandatory: no
+# Default:
+# ListenIP=0.0.0.0
+
+### Option: StartAgents
+#       Number of pre-forked instances of zabbix_agentd that process passive checks.
+#       If set to 0, disables passive checks and the agent will not listen on any TCP port.
+#
+# Mandatory: no
+# Range: 0-100
+# Default:
+# StartAgents=3
+
+##### Active checks related
+
+### Option: ServerActive
+#       List of comma delimited IP:port (or hostname:port) pairs of Zabbix servers for active checks.
+#       If port is not specified, default port is used.
+#       IPv6 addresses must be enclosed in square brackets if port for that host is specified.
+#       If port is not specified, square brackets for IPv6 addresses are optional.
+#       If this parameter is not specified, active checks are disabled.
+#       Example: ServerActive=127.0.0.1:20051,zabbix.domain,[::1]:30051,::1,[12fc::1]
+#
+# Mandatory: no
+# Default:
+# ServerActive=
+
+ServerActive=10.101.22.200
+
+### Option: Hostname
+#       Unique, case sensitive hostname.
+#       Required for active checks and must match hostname as configured on the server.
+#       Value is acquired from HostnameItem if undefined.
+#
+# Mandatory: no
+# Default:
+# Hostname=
+
+#Hostname=Zabbix server
+
+### Option: HostnameItem
+#       Item used for generating Hostname if it is undefined. Ignored if Hostname is defined.
+#       Does not support UserParameters or aliases.
+#
+# Mandatory: no
+# Default:
+# HostnameItem=system.hostname
+
+HostnameItem=system.run[hostname -f]
+
+### Option: HostMetadata
+#       Optional parameter that defines host metadata.
+#       Host metadata is used at host auto-registration process.
+#       An agent will issue an error and not start if the value is over limit of 255 characters.
+#       If not defined, value will be acquired from HostMetadataItem.
+#
+# Mandatory: no
+# Range: 0-255 characters
+# Default:
+# HostMetadata=
+HostMetadata=Linux   This_is_a_horrible_idea_for_a_shared_secret.
+
+### Option: HostMetadataItem
+#       Optional parameter that defines an item used for getting host metadata.
+#       Host metadata is used at host auto-registration process.
+#       During an auto-registration request an agent will log a warning message if
+#       the value returned by specified item is over limit of 255 characters.
+#       This option is only used when HostMetadata is not defined.
+#
+# Mandatory: no
+# Default:
+# HostMetadataItem=
+#HostMetadataItem=system.uname
+
+### Option: RefreshActiveChecks
+#       How often list of active checks is refreshed, in seconds.
+#
+# Mandatory: no
+# Range: 60-3600
+# Default:
+# RefreshActiveChecks=120
+
+### Option: BufferSend
+#       Do not keep data longer than N seconds in buffer.
+#
+# Mandatory: no
+# Range: 1-3600
+# Default:
+# BufferSend=5
+
+### Option: BufferSize
+#       Maximum number of values in a memory buffer. The agent will send
+#       all collected data to Zabbix Server or Proxy if the buffer is full.
+#
+# Mandatory: no
+# Range: 2-65535
+# Default:
+# BufferSize=100
+
+### Option: MaxLinesPerSecond
+#       Maximum number of new lines the agent will send per second to Zabbix Server
+#       or Proxy processing 'log' and 'logrt' active checks.
+#       The provided value will be overridden by the parameter 'maxlines',
+#       provided in 'log' or 'logrt' item keys.
+#
+# Mandatory: no
+# Range: 1-1000
+# Default:
+# MaxLinesPerSecond=20
+
+############ ADVANCED PARAMETERS #################
+
+### Option: Alias
+#       Sets an alias for an item key. It can be used to substitute long and complex item key with a smaller and simpler one.
+#       Multiple Alias parameters may be present. Multiple parameters with the same Alias key are not allowed.
+#       Different Alias keys may reference the same item key.
+#       For example, to retrieve the ID of user 'zabbix':
+#       Alias=zabbix.userid:vfs.file.regexp[/etc/passwd,^zabbix:.:([0-9]+),,,,\1]
+#       Now shorthand key zabbix.userid may be used to retrieve data.
+#       Aliases can be used in HostMetadataItem but not in HostnameItem parameters.
+#
+# Mandatory: no
+# Range:
+# Default:
+
+### Option: Timeout
+#       Spend no more than Timeout seconds on processing
+#
+# Mandatory: no
+# Range: 1-30
+# Default:
+# Timeout=3
+
+### Option: AllowRoot
+#       Allow the agent to run as 'root'. If disabled and the agent is started by 'root', the agent
+#       will try to switch to the user specified by the User configuration option instead.
+#       Has no effect if started under a regular user.
+#       0 - do not allow
+#       1 - allow
+#
+# Mandatory: no
+# Default:
+# AllowRoot=0
+
+### Option: User
+#       Drop privileges to a specific, existing user on the system.
+#       Only has effect if run as 'root' and AllowRoot is disabled.
+#
+# Mandatory: no
+# Default:
+# User=zabbix
+
+### Option: Include
+#       You may include individual files or all files in a directory in the configuration file.
+#       Installing Zabbix will create include directory in /usr/local/etc, unless modified during the compile time.
+#
+# Mandatory: no
+# Default:
+# Include=
+
+# Include=/usr/local/etc/zabbix_agentd.userparams.conf
+# Include=/usr/local/etc/zabbix_agentd.conf.d/
+# Include=/usr/local/etc/zabbix_agentd.conf.d/*.conf
+
+####### USER-DEFINED MONITORED PARAMETERS #######
+
+### Option: UnsafeUserParameters
+#       Allow all characters to be passed in arguments to user-defined parameters.
+#       The following characters are not allowed:
+#       \ ' " ` * ? [ ] { } ~ $ ! & ; ( ) < > | # @
+#       Additionally, newline characters are not allowed.
+#       0 - do not allow
+#       1 - allow
+#
+# Mandatory: no
+# Range: 0-1
+# Default:
+# UnsafeUserParameters=0
+
+### Option: UserParameter
+#       User-defined parameter to monitor. There can be several user-defined parameters.
+#       Format: UserParameter=<key>,<shell command>
+#       See 'zabbix_agentd' directory for examples.
+#
+# Mandatory: no
+# Default:
+# UserParameter=
+
+####### LOADABLE MODULES #######
+
+### Option: LoadModulePath
+#       Full path to location of agent modules.
+#       Default depends on compilation options.
+#
+# Mandatory: no
+# Default:
+
+### Option: LoadModule
+#       Module to load at agent startup. Modules are used to extend functionality of the agent.
+#       Format: LoadModule=<module.so>
+#       The modules must be located in directory specified by LoadModulePath.
+#       It is allowed to include multiple LoadModule parameters.
+#
+# Mandatory: no
+# Default:
+
+####### TLS-RELATED PARAMETERS #######
+
+### Option: TLSConnect
+#       How the agent should connect to server or proxy. Used for active checks.
+#       Only one value can be specified:
+#               unencrypted - connect without encryption
+#               psk         - connect using TLS and a pre-shared key
+#               cert        - connect using TLS and a certificate
+#
+# Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
+# Default:
+# TLSConnect=unencrypted
+
+### Option: TLSAccept
+#       What incoming connections to accept.
+#       Multiple values can be specified, separated by comma:
+#               unencrypted - accept connections without encryption
+#               psk         - accept connections secured with TLS and a pre-shared key
+#               cert        - accept connections secured with TLS and a certificate
+#
+# Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
+# Default:
+# TLSAccept=unencrypted
+
+### Option: TLSCAFile
+#       Full pathname of a file containing the top-level CA(s) certificates for
+#       peer certificate verification.
+#
+# Mandatory: no
+# Default:
+# TLSCAFile=
+
+### Option: TLSCRLFile
+#       Full pathname of a file containing revoked certificates.
+#
+# Mandatory: no
+# Default:
+# TLSCRLFile=
+
+### Option: TLSServerCertIssuer
+#      Allowed server certificate issuer.
+#
+# Mandatory: no
+# Default:
+# TLSServerCertIssuer=
+
+### Option: TLSServerCertSubject
+#      Allowed server certificate subject.
+#
+# Mandatory: no
+# Default:
+# TLSServerCertSubject=
+
+### Option: TLSCertFile
+#       Full pathname of a file containing the agent certificate or certificate chain.
+#
+# Mandatory: no
+# Default:
+# TLSCertFile=
+
+### Option: TLSKeyFile
+#       Full pathname of a file containing the agent private key.
+#
+# Mandatory: no
+# Default:
+# TLSKeyFile=
+
+### Option: TLSPSKIdentity
+#       Unique, case sensitive string used to identify the pre-shared key.
+#
+# Mandatory: no
+# Default:
+# TLSPSKIdentity=
+
+### Option: TLSPSKFile
+#       Full pathname of a file containing the pre-shared key.
+#
+# Mandatory: no
+# Default:
+# TLSPSKFile=

--- a/reggie_config/onsite/db.yaml
+++ b/reggie_config/onsite/db.yaml
@@ -1,0 +1,8 @@
+{%- from 'macros.jinja' import filebeat_prospector -%}
+
+filebeat:
+  enabled: True
+  config:
+    filebeat:
+      prospectors:
+        {{ filebeat_prospector('reggie-db_backup', '/var/log/reggie/db_backup.log')|indent(8) }}

--- a/reggie_config/onsite/init.yaml
+++ b/reggie_config/onsite/init.yaml
@@ -1,0 +1,33 @@
+__: merge-first
+
+reggie:
+  db:
+    backups:
+      enabled: True
+
+  plugins:
+    ubersystem:
+      config:
+        send_emails: False
+        send_sms: False
+        dev_box: True
+        at_the_con: True
+
+
+filebeat:
+  enabled: False
+  repo_managed: True
+  config:
+    filebeat:
+      registry_file: /var/lib/filebeat/registry
+    logging:
+      to_syslog: False
+      to_files: True
+      files:
+        path: /var/log/filebeat
+        name: filebeat.log
+        keepfiles: 2
+    output:
+      elasticsearch:
+        hosts:
+          - 'logs.magfest.net:9200'

--- a/reggie_config/onsite/loadbalancer.yaml
+++ b/reggie_config/onsite/loadbalancer.yaml
@@ -1,0 +1,24 @@
+{%- from 'macros.jinja' import filebeat_prospector -%}
+
+filebeat:
+  enabled: True
+  config:
+    filebeat:
+      prospectors:
+        {{ filebeat_prospector('reggie-web', '/var/log/haproxy.log', multiline=False)|indent(8) }}
+
+
+letsencrypt:
+  client:
+    email: it@magfest.org
+    source:
+      engine: pkg
+      cli: /usr/bin/certbot
+      install_units: True
+    auth:
+      method: standalone
+      type: http-01
+      port: 9999
+    domain:
+      {{ minion_id }}:
+        enabled: True

--- a/reggie_config/onsite/scheduler.yaml
+++ b/reggie_config/onsite/scheduler.yaml
@@ -1,0 +1,8 @@
+{%- from 'macros.jinja' import filebeat_prospector -%}
+
+filebeat:
+  enabled: True
+  config:
+    filebeat:
+      prospectors:
+        {{ filebeat_prospector('reggie-scheduler', '/var/log/reggie/scheduler.log')|indent(8) }}

--- a/reggie_config/onsite/web.yaml
+++ b/reggie_config/onsite/web.yaml
@@ -1,0 +1,9 @@
+{%- from 'macros.jinja' import filebeat_prospector -%}
+
+filebeat:
+  enabled: True
+  config:
+    filebeat:
+      prospectors:
+        {{ filebeat_prospector('reggie-web', '/var/log/reggie/web.log')|indent(8) }}
+        {{ filebeat_prospector('nginx', '/var/log/nginx/*.log', multiline=False)|indent(8) }}

--- a/reggie_config/onsite/worker.yaml
+++ b/reggie_config/onsite/worker.yaml
@@ -1,0 +1,8 @@
+{%- from 'macros.jinja' import filebeat_prospector -%}
+
+filebeat:
+  enabled: True
+  config:
+    filebeat:
+      prospectors:
+        {{ filebeat_prospector('reggie-worker', '/var/log/reggie/worker.log')|indent(8) }}


### PR DESCRIPTION
Three changes here:

1) Checking in a docker_magbot change which has been hanging around uncommitted for awhile.

2) Adding pillar files for the ``onsite`` env.  These are mostly just copies of the ``prod`` env files, with a few tweaks (e.g. the onsite server is currently set to ``dev_box: true``).

3) Checking in the ``zabbix`` states that the techops folks asked us to add.  These are mostly taken from https://github.com/magfest/salt-rules/blob/master/zabbix/init.sls