### PR TITLE
fixed group_prereg_takedown

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -54,7 +54,7 @@ reggie:
           epoch: 2020-01-02 08
           eschaton: 2020-01-05 20
           prereg_takedown: 2020-01-02
-          group_prereg_takedown: 2020-01-02
+          group_prereg_takedown: 2020-01-01
           badge_price_waived: 2020-01-05 14
           refund_start: 2019-09-30
           refund_cutoff: 2019-10-31


### PR DESCRIPTION
We accidentally set groups to go offline tonight instead of last night, which is why it was saying the price would go up rather than that group preregistration would go away at midnight last night.

This also stopped some emails from going out until tomorrow.  I've already deployed this fix the the onsite tasks server which handles the emails (which is the only place it really matters at the moment).