### PR TITLE
Make staging server post-con

### DIFF
--- a/reggie_config/super_2020_staging/init.yaml
+++ b/reggie_config/super_2020_staging/init.yaml
@@ -4,6 +4,7 @@ reggie:
   plugins:
     ubersystem:
       config:
+        post_con: True
         dates:
           dealer_reg_start: 2019-07-17 21
           refund_start: 2019-09-20


### PR DESCRIPTION
The staging server should be post-con so we can properly test post-con emails.