### PR TITLE
Fix Stock preassigned badge types. Again.

### DIFF
--- a/reggie_config/stock/init.yaml
+++ b/reggie_config/stock/init.yaml
@@ -53,6 +53,7 @@ reggie:
         groups_enabled: False
         merch_at_checkin: True
         untransferable_attrs: ['first_name','last_name','legal_name','email','birthdate','zip_code','international','ec_name','ec_phone','cellphone','interests','age_group','staffing','requested_depts','waiver_consent','license_plate','site_number','coming_as','camping_type','coming_with','site_type','noise_level','allergies']
+        preassigned_badge_types: ["staff_badge"]
 
         admin_email: MAGFest Sys Admin <sysadmin@magfest.org>
         regdesk_email: MAGStock Registration <admin@magstock.org>


### PR DESCRIPTION
Somehow this config option got unset, causing the server to still crash.