### PR TITLE
Remove 5XL shirt from MAGStock kick-in options

### DIFF
--- a/reggie_config/stock/init.yaml
+++ b/reggie_config/stock/init.yaml
@@ -99,12 +99,11 @@ reggie:
             xx-large: 5
             xxx-large: 6
             xxxx-large: 11
-            xxxxx-large: 12
             small (female): 7
             medium (female): 8
             large (female): 9
             x-large (female): 10
-            xx-large (female): 13
+            xx-large (female): 12
 
           donation_tier:
             No thanks: 0


### PR DESCRIPTION
We only offer up to 4XL shirts for MAGStock.