### PR TITLE
fix stock prod deploy

### DIFF
--- a/reggie_state/reggie_deploy/db.sls
+++ b/reggie_state/reggie_deploy/db.sls
@@ -168,7 +168,7 @@
         # Arcane black magic to delete every file while keeping the most recent
         # Safe for filenames with weird characters, spaces, or newlines
         FILE_COUNT=$(ls {{ backup_dir }}|grep \.sql\.gz$|wc -l)
-        export DISCARD_COUNT=$(expr $FILE_COUNT - $PRESERVE_COUNT)
+        DISCARD_COUNT=$(expr $FILE_COUNT - $PRESERVE_COUNT) || true
         if [ $DISCARD_COUNT -gt 0 ]; then
           ls -Bt {{ backup_dir }}|grep \.sql\.gz$|tail -n $DISCARD_COUNT|tr '\n' '\0'|xargs -0 printf "%b\0"|xargs -0 rm --
         fi

--- a/reggie_state/reggie_deploy/db.sls
+++ b/reggie_state/reggie_deploy/db.sls
@@ -168,7 +168,7 @@
         # Arcane black magic to delete every file while keeping the most recent
         # Safe for filenames with weird characters, spaces, or newlines
         FILE_COUNT=$(ls {{ backup_dir }}|grep \.sql\.gz$|wc -l)
-        DISCARD_COUNT=$(expr $FILE_COUNT - $PRESERVE_COUNT)
+        export DISCARD_COUNT=$(expr $FILE_COUNT - $PRESERVE_COUNT)
         if [ $DISCARD_COUNT -gt 0 ]; then
           ls -Bt {{ backup_dir }}|grep \.sql\.gz$|tail -n $DISCARD_COUNT|tr '\n' '\0'|xargs -0 printf "%b\0"|xargs -0 rm --
         fi


### PR DESCRIPTION
Ok, so I eventually figured out the issue.

Apparently the ``expr`` utility returns a non-zero exit code if the result of the math it's doing is ``0``.  So saying

```bash
FOO=$(expr 7- 6)
```

returns a 0 exit code, but saying

```bash
FOO=$(expr 7 - 7)
```

returns a 1 exit code, which is why our script was failing.

There's not a command line option we can use to tell ``expr`` to not do this, but an easy workaround is to just add a ``|| true`` to the end of the line, which is a common way to tell bash to ignore a nonzero exit code.