### PR TITLE
Use correct URLs for volunteer checklist

### DIFF
--- a/reggie_config/west_2020/init.yaml
+++ b/reggie_config/west_2020/init.yaml
@@ -235,8 +235,8 @@ reggie:
                 are imported as staff next year, maintain eligibility for hotel crash space, etc.
 
         volunteer_checklist:
-          2: signups/food_item.html
-          3: signups/shirt_item.html
-          4: hotel_requests/hotel_item.html
-          98: signups/volunteer_agreement_item.html
-          99: signups/shifts_item.html
+          2: staffing/food_item.html
+          3: staffing/shirt_item.html
+          4: staffing/hotel_item.html
+          98: staffing/volunteer_agreement_item.html
+          99: staffing/shifts_item.html


### PR DESCRIPTION
(Hopefully) fixes the 500 error when trying to access West's volunteer checklist.