### PR TITLE
Extend deadline for Staff badges

### DIFF
--- a/reggie_config/west_2020/init.yaml
+++ b/reggie_config/west_2020/init.yaml
@@ -48,7 +48,7 @@ reggie:
           uber_takedown: 2020-09-16
           room_deadline: 2020-07-31
 
-          printed_badge_deadline: 2020-08-06
+          printed_badge_deadline: 2020-10-04
 
           # Dealer registration automatically opens on DEALER_REG_START.  After DEALER_REG_DEADLINE
           # all dealer registration are automatically waitlisted.  After DEALER_REG_SHUTDOWN dealers


### PR DESCRIPTION
I'm pretty sure we're not going to physically print any badges prior to the event, so the deadline for printed badges can be the same as the eschaton.