### PR TITLE
Re-remove hotel eligible checklist step

### DIFF
--- a/reggie_config/super_2021/init.yaml
+++ b/reggie_config/super_2021/init.yaml
@@ -254,7 +254,7 @@ reggie:
             deadline: 2021-12-18
 
           hotel_eligible:
-            deadline: 2021-12-18
+            deadline: ''
 
           approve_setup_teardown:
             deadline: 2021-12-18


### PR DESCRIPTION
The "hotel eligible" checklist step is actually commented out from Super 2020 because we used Tuber for hotel rooms, so we still don't want it.