### PR TITLE
Update prereg-relevant dates

### DIFF
--- a/reggie_config/super_2022/init.yaml
+++ b/reggie_config/super_2022/init.yaml
@@ -51,22 +51,22 @@ reggie:
         mits_email: "MAGFest Indie Tabletop Showcase <mits@magfest.org>"
 
         dates:
-          prereg_open: 2022-09-10 15
-          prereg_hotel_eligibility_cutoff: 2021-09-17
-          shifts_created: 2021-10-27
+          prereg_open: 2021-09-29 15
+          prereg_hotel_eligibility_cutoff: 2021-10-06
+          shifts_created: 2021-10-31
           room_deadline: 2021-11-14
           drop_shifts_deadline: 2022-1-15
           shirt_deadline: 2021-12-31
           supporter_deadline: 2021-12-31
-          placeholder_deadline: 2021-12-26
-          uber_takedown: 2022-01-07
-          epoch: 2022-01-22 08
-          eschaton: 2022-01-24 23
-          prereg_takedown: 2022-01-02
+          placeholder_deadline: 2021-12-31
+          uber_takedown: 2022-01-09
+          epoch: 2022-01-06 08
+          eschaton: 2022-01-09 23
+          prereg_takedown: ''
           group_prereg_takedown: 2022-01-01
-          badge_price_waived: 2022-01-05 14
-          refund_start: 2021-09-30
-          refund_cutoff: 2021-10-31
+          badge_price_waived: 2022-01-09 14
+          refund_start: ''
+          refund_cutoff: ''
 
           printed_badge_deadline: 2021-12-03
 


### PR DESCRIPTION
A lot of these are just guesses based on what I know is happening, but we need to update at least some of them before sending emails out to volunteers.