### PR TITLE
Add python2.7 flag to Super 2022

### DIFF
--- a/magfest_state/salt/cloud/files/cloud.profiles.d/reggie-super-2022-profiles.conf
+++ b/magfest_state/salt/cloud/files/cloud.profiles.d/reggie-super-2022-profiles.conf
@@ -10,6 +10,7 @@ super-2022-base-prod:
   image: ubuntu-18-04-x64
   location: nyc1
   private_networking: True
+  script_args: -x python2.7
   tags:
     - production
     - reggie


### PR DESCRIPTION
We need this flag now that we had to update how Salt is installed on minions, otherwise Jinja2 throws errors trying to run a deploy.