### PR TITLE
Enable emergency procedures for Super

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -34,6 +34,7 @@ reggie:
 
         accessibility_services_enabled: True
         volunteer_agreement_enabled: True
+        emergency_procedures_enabled: True
         require_dedicated_guest_table_presence: True
         rock_island_groups: ['band', 'guest']
 


### PR DESCRIPTION
We will almost always want this checklist step for Super events.