### PR TITLE
Actually turn off MIVS checklist steps

### DIFF
--- a/reggie_config/super_2022/init.yaml
+++ b/reggie_config/super_2022/init.yaml
@@ -247,6 +247,7 @@ reggie:
               In exchange for your space and two free badges, MIVS expects your studio to have your booth area
               up-and-running during core hours. You also must have at least one representative from your studio present,
               in your booth, during core hours.
+
           discussion:
             deadline: 2021-11-07
             name: MIVS Discussion Group
@@ -254,14 +255,15 @@ reggie:
             description: >
               The primary contact for your game will be added to a MIVS Google Discussion group. You may
               enter emails for any team members associated with your game who you think should also be added to the group.
-          hotel_space:
-            deadline: 2021-11-10
-            name: Hotel Signups
-            editable: True
-            description: >
-              As a part of MIVS, you may purchase one hotel room for the Gaylord. This room is for your
-              use and you are not allowed to transfer your reservation to someone else unless authorized
-              by MAGFest. Dropping out of MIVS may cause your room to be canceled.
+
+#          hotel_space:
+#            deadline: 2021-11-10
+#            name: Hotel Signups
+#            editable: True
+#            description: >
+#              As a part of MIVS, you may purchase one hotel room for the Gaylord. This room is for your
+#              use and you are not allowed to transfer your reservation to someone else unless authorized
+#              by MAGFest. Dropping out of MIVS may cause your room to be canceled.
           
           selling_at_event:
             start: 2021-12-01
@@ -271,6 +273,7 @@ reggie:
             description: >
               We are allowing Indies to sell items directly related to your game or studio in MIVS.
               Studios will need to sign a waiver and provide some information for tax purposes.
+
           handbook:
             start: 2021-12-10
             deadline: 2021-12-22
@@ -278,12 +281,12 @@ reggie:
             editable: True
             description: The MIVS Indie Handbook is here to give you information about being a MIVS Participant.
 
-          training:
-            start: 2021-12-26
-            deadline: 2021-12-30
-            name: MIVS Training
-            editable: True
-            description: MIVS Training is a google form to help you learn about being an Indie at MAGFest.
+#          training:
+#            start: 2021-12-26
+#            deadline: 2021-12-30
+#            name: MIVS Training
+#            editable: True
+#            description: MIVS Training is a google form to help you learn about being an Indie at MAGFest.
 
           show_info:
             deadline: 2021-12-30


### PR DESCRIPTION
Sadly you can't turn off these steps by just nullifying the deadline, so we're commenting these out for now.