### PR TITLE
Run Super 2020 off a feature branch

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -9,6 +9,7 @@ reggie:
         {{ extra_attendance_data()|indent(8) }}
   plugins:
     ubersystem:
+      branch: super2020
       config:
         app_limit: 0
         shirt_stock: 1100


### PR DESCRIPTION
We need to re-deploy to our Super 2020 server, so it needs to run the old code.