### PR TITLE
Put the Super 2020 magprime repo on its own branch

### DIFF
--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -8,6 +8,8 @@ reggie:
     plugins/uber/uber/static/analytics/extra-attendance-data.json: |
         {{ extra_attendance_data()|indent(8) }}
   plugins:
+    magprime:
+      branch: super2020
     ubersystem:
       branch: super2020
       config:


### PR DESCRIPTION
Our magprime plugin is also too new for this server, so it needs to be stamped as well.