### PR TITLE
Remove "staff event shirt" config from Super 2022

### DIFF
--- a/reggie_config/super/init.yaml
+++ b/reggie_config/super/init.yaml
@@ -85,11 +85,6 @@ reggie:
         dealer_loc_term: marketplace
         dealer_reg_term: marketplace registration
 
-        integer_enums:
-          staff_event_shirt:
-            "Two Staff Shirts": 0
-            "One Event Shirt and One Staff Shirt": 1
-
         enums:
           badge:
             attendee_badge: Attendee

--- a/reggie_config/super_2020/init.yaml
+++ b/reggie_config/super_2020/init.yaml
@@ -149,6 +149,10 @@ reggie:
           supporter_level: 85
           season_level: 200
 
+          staff_event_shirt:
+            "Two Staff Shirts": 0
+            "One Event Shirt and One Staff Shirt": 1
+
           donation_tier:
             No thanks: 0
             T-Shirt Tier: SHIRT_LEVEL


### PR DESCRIPTION
Moves the "staff event shirt" config from the default Super file to the Super 2020 file.