### PR TITLE
Increase number of blank staff badges

### DIFF
--- a/reggie_config/super_2022/init.yaml
+++ b/reggie_config/super_2022/init.yaml
@@ -16,6 +16,7 @@ reggie:
         season_stock: 230
         shared_kickin_stocks: False
         groups_enabled: False
+        blank_staff_badges: 200
         
         event_year: 2022
         event_qr_id: sm22


### PR DESCRIPTION
We need more blank staff badges than the default, and I don't feel like futzing around with the export mode.