### PR TITLE
Use 'main' branch for covid plugin

### DIFF
--- a/reggie_config/west/init.yaml
+++ b/reggie_config/west/init.yaml
@@ -12,6 +12,7 @@ reggie:
     covid:
       name: covid
       source: https://github.com/magfest/covid.git
+      branch: main
 
     ubersystem:
       config:


### PR DESCRIPTION
GitHub repos now use the 'main' branch as the default branch, so we need to tell Salt that's the right branch to use.