### PR TITLE
Make Jet Tier season-level

### DIFF
--- a/reggie_config/west/init.yaml
+++ b/reggie_config/west/init.yaml
@@ -169,7 +169,7 @@ reggie:
             No thanks: 0
             T-Shirt Bundle: SHIRT_LEVEL
             Supporter Package: SUPPORTER_LEVEL
-            Mayor's Package: SEASON_LEVEL
+            Jet Tier: SEASON_LEVEL
             
         dept_head_checklist:
           creating_shifts:


### PR DESCRIPTION
Part of fixing https://jira.magfest.net/browse/MAGDEV-1103. We need to rename the super supporter in donation_tier to give it the correct amount.