### PR TITLE
Set post-con to false for Super 2023

### DIFF
--- a/reggie_config/super_2023/init.yaml
+++ b/reggie_config/super_2023/init.yaml
@@ -21,7 +21,7 @@ reggie:
         self_service_deferrals_open: True
         merch_shipping_fee: 15
         at_the_con: False
-        post_con: True
+        post_con: False
         
         event_year: 2023
         event_qr_id: sm23


### PR DESCRIPTION
Missed this when setting up 2023's config.