### PR TITLE
Add extra staff badges for all events

### DIFF
--- a/reggie_config/init.yaml
+++ b/reggie_config/init.yaml
@@ -104,6 +104,7 @@ reggie:
         privacy_policy_url: 'https://super.magfest.org/privacy-policy'
         jira_enabled: true
         attendee_accounts_enabled: false
+        blank_staff_badges: 50
 
         panels_twilio_number: '+12405415595'
         tabletop_twilio_number: '+15713646627'


### PR DESCRIPTION
We always want to print extra staff badges out and I keep forgetting how this works. Now we automatically get at least 50.