### PR TITLE
Use temporary feature branch for Super 2023

### DIFF
--- a/reggie_config/super_2023/init.yaml
+++ b/reggie_config/super_2023/init.yaml
@@ -9,6 +9,7 @@ reggie:
         {{ extra_attendance_data()|indent(8) }}
   plugins:
     ubersystem:
+      branch: super2023
       config:
         app_limit: 0
         shirt_stock: 0 #950


### PR DESCRIPTION
We need to run Super 2023 with some major changes that we don't want in MAGWest, so we're going to run it off a feature branch until West is over.