### PR TITLE
Remove event shirts for volunteers

### DIFF
--- a/reggie_config/super_2023/init.yaml
+++ b/reggie_config/super_2023/init.yaml
@@ -19,6 +19,7 @@ reggie:
         groups_enabled: True
         blank_staff_badges: 200
         shirts_per_staffer: 1
+        hours_for_shirt: 0
         self_service_deferrals_open: False
         merch_shipping_fee: 15
         at_the_con: False


### PR DESCRIPTION
Volunteers for Super no longer have a shirt in their perks, so we should set hours_for_shirt to none