### PR TITLE
Fix age ranges for discount policy

### DIFF
--- a/reggie_config/super_2023/init.yaml
+++ b/reggie_config/super_2023/init.yaml
@@ -176,13 +176,13 @@ reggie:
 
         age_groups:
           under_6:
-            desc: "Under 5"
+            desc: "Under 6"
             min_age: 0
-            max_age: 4
+            max_age: 5
 
           under_12:
-            desc: "Between 5 and 12"
-            min_age: 5
+            desc: "Between 6 and 12"
+            min_age: 6
             max_age: 11
             can_volunteer: False
 


### PR DESCRIPTION
We were still using Super 2021's age group policy, which was slightly different from 2020's because kids under 5 couldn't attend. Our FAQs state that kids under six get a discount, so we need to fix this.