### PR TITLE
Add W9 deadline to checklists

### DIFF
--- a/reggie_config/super_2023/init.yaml
+++ b/reggie_config/super_2023/init.yaml
@@ -126,7 +126,7 @@ reggie:
           band_charity_deadline: 2022-11-18
           band_rehearsal_deadline: 2022-11-25
 
-          band_taxes_deadline: 2022-11-20
+          band_taxes_deadline: 2022-11-25 # Always just set this to the latest checklist date
 
           band_info_deadline: ''
           band_mc_deadline: ''
@@ -139,7 +139,7 @@ reggie:
           guest_interview_deadline: 2022-12-05
           guest_travel_plans_deadline: 2022-12-05
           
-          guest_taxes_deadline: 2022-10-21
+          guest_taxes_deadline: 2022-12-05 # Always just set this to the latest checklist date
           
           guest_info_deadline: ''
           guest_merch_deadline: ''


### PR DESCRIPTION
We don't really use this step anymore, but it doesn't show up unless you set a group as having payment owed so it's safe to set a deadline for this step.